### PR TITLE
SNO2-25-multiple-types

### DIFF
--- a/src/snosearch/fields.py
+++ b/src/snosearch/fields.py
@@ -39,6 +39,7 @@ from .queries import BasicReportQueryFactoryWithoutFacets
 from .queries import CachedFacetsQueryFactory
 from .queries import CollectionSearchQueryFactoryWithFacets
 from .queries import MissingMatrixQueryFactoryWithFacets
+from .queries import MultitypeMissingMatrixQueryFactoryWithFacets
 from .responses import AuditMatrixResponseWithFacets
 from .queries import TopHitsQueryFactory
 from .responses import BasicMatrixResponseWithFacets
@@ -313,6 +314,20 @@ class MissingMatrixWithFacetsResponseField(BasicMatrixWithFacetsResponseField):
 
     def _build_query(self):
         self.query_builder = MissingMatrixQueryFactoryWithFacets(
+            params_parser=self.get_params_parser(),
+            **self.kwargs
+        )
+        self.query = self.query_builder.build_query()
+
+
+class MultitypeMissingMatrixWithFacetsResponseField(MissingMatrixWithFacetsResponseField):
+    '''
+    Like MissingMatrixWithFacetsResponseField but uses MultitypeMissingMatrixQueryFactoryWithFacets
+    query.
+    '''
+
+    def _build_query(self):
+        self.query_builder = MultitypeMissingMatrixQueryFactoryWithFacets(
             params_parser=self.get_params_parser(),
             **self.kwargs
         )

--- a/src/snosearch/queries.py
+++ b/src/snosearch/queries.py
@@ -1319,6 +1319,14 @@ class MissingMatrixQueryFactoryWithFacets(BasicMatrixQueryFactoryWithFacets):
         ]
 
 
+class MultitypeMissingMatrixQueryFactoryWithFacets(MissingMatrixQueryFactoryWithFacets):
+    '''
+    Like MissingMatrixQueryFactoryWithFacets but allows multiple item types in the query.
+    '''
+    def _get_item_types(self):
+        return super(BasicMatrixQueryFactoryWithFacets, self)._get_item_types()
+
+
 class AuditMatrixQueryFactoryWithFacets(BasicMatrixQueryFactoryWithFacets):
     '''
     Like BasicMatrixQueryFactoryWithFacets but adds aggregation for all audit fields.

--- a/src/snosearch/tests/test_searches_fields.py
+++ b/src/snosearch/tests/test_searches_fields.py
@@ -1063,6 +1063,31 @@ def test_searches_fields_missing_matrix_with_facets_response_field_build_query(d
     assert isinstance(mmwf.query_builder, MissingMatrixQueryFactoryWithFacets)
 
 
+def test_searches_fields_multitype_missing_matrix_with_facets_response_field_init():
+    from snosearch.fields import MultitypeMissingMatrixWithFacetsResponseField
+    mmmwf = MultitypeMissingMatrixWithFacetsResponseField()
+    assert isinstance(mmmwf, MultitypeMissingMatrixWithFacetsResponseField)
+
+
+@pytest.mark.parametrize(
+    'dummy_parent',
+    integrations,
+    indirect=True
+)
+def test_searches_fields_multitype_missing_matrix_with_facets_response_field_build_query(dummy_parent):
+    from snosearch.fields import MultitypeMissingMatrixWithFacetsResponseField
+    from snosearch.queries import MultitypeMissingMatrixQueryFactoryWithFacets
+    from elasticsearch_dsl import Search
+    dummy_parent._meta['params_parser']._request.environ['QUERY_STRING'] = (
+        'type=TestingSearchSchema&status=released'
+    )
+    mmmwf = MultitypeMissingMatrixWithFacetsResponseField()
+    mmmwf.parent = dummy_parent
+    mmmwf._build_query()
+    assert isinstance(mmmwf.query, Search)
+    assert isinstance(mmmwf.query_builder, MultitypeMissingMatrixQueryFactoryWithFacets)
+
+
 @pytest.mark.parametrize(
     'dummy_parent',
     integrations,

--- a/src/snosearch/tests/test_searches_queries.py
+++ b/src/snosearch/tests/test_searches_queries.py
@@ -6383,6 +6383,42 @@ def test_searches_queries_missing_matrix_query_factory_with_facets_add_matrix_ag
     integrations,
     indirect=True
 )
+def test_searches_queries_multitype_missing_matrix_query_factory_with_facets_init(params_parser):
+    from snosearch.queries import MultitypeMissingMatrixQueryFactoryWithFacets
+    mmmqf = MultitypeMissingMatrixQueryFactoryWithFacets(params_parser)
+    assert isinstance(mmmqf, MultitypeMissingMatrixQueryFactoryWithFacets)
+    assert mmmqf.params_parser == params_parser
+
+
+@pytest.mark.parametrize(
+    'params_parser, dummy_request',
+    [
+        ('pyramid', 'pyramid'),
+        ('flask', 'flask')
+    ],
+    indirect=True
+)
+def test_searches_queries_multitype_missing_matrix_query_factory_with_facets_parse_name_and_default_value_from_name(params_parser, dummy_request):
+    from snosearch.queries import MultitypeMissingMatrixQueryFactoryWithFacets
+    from elasticsearch_dsl.aggs import Terms
+    dummy_request.environ['QUERY_STRING'] = (
+        'type=TestingSearchSchema&status=released'
+        '&limit=10&field=@id&field=accession&mode=picker'
+    )
+    mmqf = MultitypeMissingMatrixQueryFactoryWithFacets(params_parser)
+    name, default_value = mmqf._parse_name_and_default_value_from_name('perturbation_type')
+    assert name == 'perturbation_type'
+    assert default_value is None
+    name, default_value = mmqf._parse_name_and_default_value_from_name(('perturbation_type', 'no_perturbation'))
+    assert name == 'perturbation_type'
+    assert default_value == 'no_perturbation'
+
+
+@pytest.mark.parametrize(
+    'params_parser',
+    integrations,
+    indirect=True
+)
 def test_searches_queries_audit_matrix_query_factory_with_facets_init(params_parser):
     from snosearch.queries import AuditMatrixQueryFactoryWithFacets
     amqf = AuditMatrixQueryFactoryWithFacets(params_parser)


### PR DESCRIPTION
I didn’t repeat all the `test_searches_queries_missing_matrix` tests for the multitype matrix since I figured the missing matrix ones mostly just get tested again with the multitype matrix tests. Not sure if you agree. I also didn’t test the one thing that makes the multitype matrix different from the missing matrix — multiple types — since we only have one `TestingSearchSchema` defined, and I wasn’t sure if I should define another one.